### PR TITLE
Fix loading positioning and bios route

### DIFF
--- a/src/pages/Bios/DesktopBios/index.js
+++ b/src/pages/Bios/DesktopBios/index.js
@@ -128,9 +128,8 @@ const Image = styled.img`
 `;
 
 export default function DesktopBios() {
-  const { performers, apprentices, guestPerformers, staff } = useContext(
-    ResourcesContext
-  ).resourceObj;
+  const { performers, apprentices, guestPerformers, staff } =
+    useContext(ResourcesContext).resourceObj;
   const [data, setData] = useState({
     role: "performers",
     resouces: performers,

--- a/src/pages/Loading/index.js
+++ b/src/pages/Loading/index.js
@@ -2,71 +2,65 @@ import React from "react";
 import style, { keyframes } from "styled-components/macro";
 
 const leftLine = keyframes`
-      0%,
-      100% {
-        transform: translateX(-100%) scaleX(1);
-      }
-
-      25%,
-      75% {
-        transform: translateX(-25%) scaleX(1);
-      }
-
-      50% {
-        transform: translateX(50%) scaleX(0.3);
-      }
-
-    }`;
+0%,
+100% {
+  transform: translateX(-100%) scaleX(1);
+}
+25%,
+75% {
+  transform: translateX(-25%) scaleX(1);
+}
+50% {
+  transform: translateX(50%) scaleX(0.3);
+}`;
 
 const rightLine = keyframes`
-      0%,
-      100% {
-        transform: translateX(100%) scaleX(1);
-      }
+0%,
+100% {
+  transform: translateX(100%) scaleX(1);
+}
 
-      25%,
-      75% {
-        transform: translateX(25%) scaleX(1);
-      }
+25%,
+75% {
+  transform: translateX(25%) scaleX(1);
+}
 
-      50% {
-        transform: translateX(-50%) scaleX(0.3);
-      }
-    }
-`;
+50% {
+  transform: translateX(-50%) scaleX(0.3);
+}`;
 const duration = 3;
 const thickness = 3;
 
 const Lines = style.div`
-      position: fixed;
-      z-index: 100;
-      background-color: black;
-      width: 100vw;
-      height: 100vh;
-      animation-fill-mode: forwards;
+position: relative;
+z-index: 100;
+background-color: black;
+width: 100vw;
+height: 100vh;
+animation-fill-mode: forwards;
 
-     &::before,
-   &::after {
-      position: absolute;
-      display: block;
-      top: 50%;
-      width: 50%;
-      height: ${thickness}px;
-      content: ' ';
-      background-color: white;
-    }
+&::before,
+&::after {
+  position: absolute;
+  display: block;
+  top: 50%;
+  width: 50%;
+  height: ${thickness}px;
+  content: ' ';
+  background-color: white;
+}
 
-   &::before {
-      animation: ${leftLine} linear ${duration}s infinite;
-      left: 0;
-      transform: translateX(-100%);
-    }
+&::before {
+  animation: ${leftLine} linear ${duration}s infinite;
+  left: 0;
+  transform: translateX(-100%);
+}
 
-   &::after {
-      animation: ${rightLine} linear ${duration}s infinite;
-      right: 0;
-      transform: translateX(100%);
-`;
+&::after {
+  animation: ${rightLine} linear ${duration}s infinite;
+  right: 0;
+  transform: translateX(100%);
+}`;
 
 const Loading = () => <Lines />;
 

--- a/src/styledGuide/Bio/index.js
+++ b/src/styledGuide/Bio/index.js
@@ -47,13 +47,12 @@ const StyledMarkdown = styled(Markdown)`
 const src = (images) => {
   console.log(images);
   let image;
-  images.forEach((img) => {
+  images?.forEach((img) => {
     if (img.title.includes("headshot")) {
       image = img.src;
     } else {
       image = images[0]?.src;
     }
-    // console.log(img.title.includes("headshot"));
   });
   return { image };
 };

--- a/src/styledGuide/Image/index.js
+++ b/src/styledGuide/Image/index.js
@@ -34,7 +34,7 @@ export function Image({ src, alt, credit, imageSize, ...props }) {
   const role = alt ? undefined : "presentation";
 
   const srcString = getSrcString(src);
-  const combinedAlt = alt || (src && src.title) ? src.title : undefined;
+  const combinedAlt = alt ?? src?.title ?? undefined;
 
   if (!srcString) return null;
   return (


### PR DESCRIPTION
- Remove fixed positioning from Loading, this makes it consistent with the previous implementation (green bubbles)
- Prevent crash in bios page when images haven't loaded yet or are missing title data
- This PR does not address the repertoire route where images per performance are still not found (although it no longer crashes)